### PR TITLE
Add Fix For Mac Computers With Dataloader Processes

### DIFF
--- a/scripts/test_driver.py
+++ b/scripts/test_driver.py
@@ -1,5 +1,7 @@
+from os import cpu_count
 from utils.TrainModels import TrainModels
 
+ON_MAC_COMPUTER = False
 SEQ_LEN = 100
 
 model_trainer = TrainModels(seq_len=SEQ_LEN)
@@ -10,7 +12,9 @@ trained_perc_model = model_trainer.train_perceptron()
 
 # Train RNN
 print("Now training RNN....")
-trained_rnn_model = model_trainer.train_RNN(batch_size=32)
+num_dataloader_processes = 0 if ON_MAC_COMPUTER else cpu_count()
+trained_rnn_model = model_trainer.train_RNN(batch_size=32,
+                            num_dataloader_processes=num_dataloader_processes)
 
 # TODO: Train LSTM
 

--- a/scripts/utils/TrainModels.py
+++ b/scripts/utils/TrainModels.py
@@ -161,6 +161,7 @@ class TrainModels:
         return clf
 
     def train_RNN(self,
+                  num_dataloader_processes: int,
                   hidden_size: int=64,
                   num_layers: int=2,
                   nonlinearity: str="tanh",
@@ -171,6 +172,8 @@ class TrainModels:
                   stopping_lr: float=0.0001):
         """
         Args:
+            num_dataloader_processes (int): Number of processes to use for
+                dataloading.
             hidden_size (int): Number of features in each hidden state layer.
             num_layers (int): Number of recurrent layers. Any number greater
                 than 1 results in a "stacked RNN".
@@ -192,11 +195,11 @@ class TrainModels:
         train_dataloader = DataLoader(dataset=self.train_dataset,
                                       batch_size=batch_size,
                                       shuffle=True,
-                                      num_workers=cpu_count())
+                                      num_workers=num_dataloader_processes)
         test_dataloader = DataLoader(dataset=self.test_dataset,
                                      batch_size=batch_size,
                                      shuffle=True,
-                                     num_workers=cpu_count())
+                                     num_workers=num_dataloader_processes)
 
         # Create RNN instance
         rnn_model = torch.compile(RNN(


### PR DESCRIPTION
Make a variable on the top of test_driver.py that allows training on Macs to run without error.