### PR TITLE
Make Perceptron Use PyTorch For Testing Uniformity + Other Tweaks

### DIFF
--- a/scripts/test_driver.py
+++ b/scripts/test_driver.py
@@ -13,22 +13,27 @@ num_dataloader_processes = 0 if ON_MAC_COMPUTER else cpu_count()
 
 # Train Perceptron
 print("Now training Perceptron....")
-trained_perc_model = model_trainer.train_perceptron()
+trained_perc_model = model_trainer.train_perceptron(
+                            num_dataloader_processes=num_dataloader_processes,
+                            batch_size=32)
 
 # Train RNN
 print("Now training RNN....")
-trained_rnn_model = model_trainer.train_RNN(batch_size=32,
-                            num_dataloader_processes=num_dataloader_processes)
+trained_rnn_model = model_trainer.train_RNN(
+                            num_dataloader_processes=num_dataloader_processes,
+                            batch_size=32)
 
 # Train LSTM
 print("Now training LSTM....")
-trained_lstm_model = model_trainer.train_LSTM(num_dataloader_processes=num_dataloader_processes,
-                                              batch_size=32)
+trained_lstm_model = model_trainer.train_LSTM(
+                            num_dataloader_processes=num_dataloader_processes,
+                            batch_size=32)
 
 # Train Transformer
 print("Now training Transformer....")
 trained_transformer_model = model_trainer.train_transformer(
-                            num_dataloader_processes=num_dataloader_processes)
+                            num_dataloader_processes=num_dataloader_processes,
+                            batch_size=32)
 
 # TODO: Evaluate Perceptron
 

--- a/scripts/utils/models/Perceptron.py
+++ b/scripts/utils/models/Perceptron.py
@@ -1,0 +1,35 @@
+import torch
+from torch import nn
+
+class Perceptron(nn.Module):
+    def __init__(self,
+                 input_size: int,
+                 seq_len: int,
+                 bias: bool):
+        """
+        Args:
+            input_size (int): Number of expected features per date.
+            bias (bool): If bias weights should be used in every layer.
+        """
+        super().__init__()
+
+        # Define layers of network
+        self.flatten = nn.Flatten()
+        self.linear = nn.Linear(in_features=input_size * seq_len,
+                                out_features=1,
+                                bias=bias)
+
+    def forward(self, x: torch.Tensor):
+        """
+        Args:
+            x (torch.Tensor): A tensor to return predictions for with dimensions
+                (batch_size, seq_len, features).
+
+        Returns:
+            A torch.Tensor of the predicted next day values with the dimensions
+            (batch_size, 1).
+        """
+        # Run input through norm layer to prevent nan values from outliers later
+        x = nn.functional.normalize(x, dim=2)
+
+        return self.linear(self.flatten(x))


### PR DESCRIPTION
Move the Perceptron model to PyTorch to allow equal footing while running testing later on.